### PR TITLE
UX safeguards

### DIFF
--- a/app/(tabs)/custom.tsx
+++ b/app/(tabs)/custom.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { ActivityIndicator, Alert, Keyboard, KeyboardAvoidingView, Platform, Pressable, Share, StyleSheet, Text, TextInput, TouchableWithoutFeedback, View } from 'react-native';
+import { ActivityIndicator, Alert, Keyboard, KeyboardAvoidingView, Platform, Pressable, Share, StyleSheet, Text, TextInput, ToastAndroid, TouchableWithoutFeedback, View } from 'react-native';
 import { generateAffirmation, toAffirmation } from '../../lib/api';
 import { saveFavorite } from '../../lib/storage';
 import { Affirmation } from '../../lib/types';
@@ -38,7 +38,11 @@ export default function CustomScreen() {
 
   const handleSave = async (aff: Affirmation) => {
     await saveFavorite(aff);
-    Alert.alert('Saved to favorites');
+    if (Platform.OS === 'android') {
+      ToastAndroid.show('Saved to favorites', ToastAndroid.SHORT);
+    } else {
+      Alert.alert('Saved to favorites');
+    }
   };
 
   const handleCopy = async (text: string) => {

--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -1,6 +1,6 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { useCallback, useState } from 'react';
-import { ActivityIndicator, Alert, FlatList, Share, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, Alert, FlatList, Platform, Share, StyleSheet, Text, ToastAndroid, View } from 'react-native';
 import { getFavorites, removeFavorite } from '../../lib/storage';
 import { Affirmation } from '../../lib/types';
 import AffirmationCard from '../components/AffirmationCard';
@@ -26,7 +26,11 @@ export default function FavoritesScreen() {
     try {
       const Clipboard = await import('expo-clipboard');
       await Clipboard.setStringAsync(text);
-      Alert.alert('Copied');
+      if (Platform.OS === 'android') {
+        ToastAndroid.show('Copied', ToastAndroid.SHORT);
+      } else {
+        Alert.alert('Copied');
+      }
     } catch {
       Alert.alert('Copy failed', 'Install expo-clipboard to enable copy');
     }
@@ -49,7 +53,11 @@ export default function FavoritesScreen() {
         onPress: async () => {
           const next = await removeFavorite(id);
           setFavorites(next);
-          Alert.alert('Removed');
+          if (Platform.OS === 'android') {
+            ToastAndroid.show('Removed', ToastAndroid.SHORT);
+          } else {
+            Alert.alert('Removed');
+          }
         },
       },
     ]);


### PR DESCRIPTION
- Home: added a soft 3s cooldown on Regenerate, a Retry button on error, and toast-style feedback (ToastAndroid on Android; Alert elsewhere). Save now uses toasts.
- Custom: Save now uses a toast on Android.
- Favorites: Copy and Delete show toasts on Android; Alert on iOS/web.